### PR TITLE
Update go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/umasii/urlValues
+module github.com/RambIing/urlValues
 
 go 1.16


### PR DESCRIPTION
You probably want to change this back so others can actually install this package without the following error:
```
$ go get github.com/RambIing/urlValues
go get: github.com/RambIing/urlValues@none updating to
        github.com/RambIing/urlValues@v0.0.0-20210622220818-c5bb9e617556: parsing go.mod:
        module declares its path as: github.com/umasii/urlValues
                but was required as: github.com/RambIing/urlValues

```