### PR TITLE
Fix sorting & add tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/umasii/urlValues
+module github.com/RambIing/urlValues
 
 go 1.16

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/RambIing/urlValues
+module github.com/Sleeyax/urlValues
 
 go 1.16

--- a/urlValues.go
+++ b/urlValues.go
@@ -9,8 +9,10 @@ import (
 	"sort"
 	"strings"
 )
+
 type Values map[string][]string
 type encoding int
+
 const (
 	encodePath encoding = 1 + iota
 	encodePathSegment
@@ -81,7 +83,9 @@ func (v Values) Del(key string) {
 func QueryEscape(s string) string {
 	return escape(s, encodeQueryComponent)
 }
+
 const upperhex = "0123456789ABCDEF"
+
 func escape(s string, mode encoding) string {
 	spaceCount, hexCount := 0, 0
 	for i := 0; i < len(s); i++ {

--- a/urlValues.go
+++ b/urlValues.go
@@ -13,7 +13,7 @@ import (
 type Values map[string][]string
 type encoding int
 
-const OrderKey = "ORDER"
+const OrderKey = "_GO_ORDER"
 
 const (
 	encodePath encoding = 1 + iota

--- a/urlValues_test.go
+++ b/urlValues_test.go
@@ -1,0 +1,28 @@
+package urlValues
+
+import (
+	"testing"
+)
+
+func getValues() Values {
+	values := Values{}
+	values.Add("xyz", "abc")
+	values.Add("abc", "xyz")
+	return values
+}
+
+func TestValues_Encode(t *testing.T) {
+	values := getValues()
+
+	if values.Encode() != "abc=xyz&xyz=abc" {
+		t.FailNow()
+	}
+}
+
+func TestValues_EncodeWithOrder(t *testing.T) {
+	values := getValues()
+
+	if values.EncodeWithOrder() != "xyz=abc&abc=xyz" {
+		t.FailNow()
+	}
+}

--- a/urlValues_test.go
+++ b/urlValues_test.go
@@ -17,6 +17,12 @@ func TestValues_Encode(t *testing.T) {
 	if values.Encode() != "abc=xyz&xyz=abc" {
 		t.FailNow()
 	}
+
+	values.Del("xyz")
+
+	if values.EncodeWithOrder() != "abc=xyz" {
+		t.Fatalf("failed to delete item")
+	}
 }
 
 func TestValues_EncodeWithOrder(t *testing.T) {
@@ -24,5 +30,17 @@ func TestValues_EncodeWithOrder(t *testing.T) {
 
 	if values.EncodeWithOrder() != "xyz=abc&abc=xyz" {
 		t.FailNow()
+	}
+
+	values[OrderKey] = []string{"abc", "xyz"}
+
+	if values.EncodeWithOrder() != "abc=xyz&xyz=abc" {
+		t.Fatalf("failed to manually rearrange order")
+	}
+
+	values.Del("abc")
+
+	if values.EncodeWithOrder() != "xyz=abc" && len(values[OrderKey]) != 1 {
+		t.Fatalf("failed to fully delete item")
 	}
 }


### PR DESCRIPTION
Following the example in your README, `EncodeWithOrder()` didn't output the same expected outputs, so here's a fix.

Overview of my changes:
- Renamed `main.go` to `urlValues.go` since this is a library and not a runnable Go program within the `main` package. If you disagree with me on this one for whatever reason feel free to undo this change, but I assumed you would agree.
- Added 2 simple unit tests that actually test the code in the README.
- Fixed order not working. `values.Add(k, v)` will now automatically update the order internally, so you don't *have* to specify the order manually anymore through the `ORDER` key on the map.
- Rename `ORDER` key to `_GO_ORDER` to avoid weird edge cases with some forms that require a 'ORDER' field, which is more likely than '_GO_ORDER'. It's still not 100% idiot-proof, but less likely. (Tip: this could be made 100% idiot-proof by wrapping the values map & order separately in a struct)